### PR TITLE
fix from to

### DIFF
--- a/lib/extendy.js
+++ b/lib/extendy.js
@@ -1,27 +1,27 @@
 (function(global) {
     'use strict';
-    
+
     if (typeof module !== 'undefined' && module.exports)
         module.exports = extendy;
     else
         global.extendy = extendy;
-    
+
     function extendy(to, from) {
         check(to, from);
-        
-        Object.keys(to).forEach(function(name) {
-            from[name] = to[name];
+
+        Object.keys(from).forEach(function(name) {
+            to[name] = from[name];
         });
     }
-    
+
     function check(to, from) {
         var empty = 'could not be empty!';
-        
+
         if (!to)
             throw(Error('to ' + empty));
-        
+
         if (!from)
             throw(Error('from ' + empty));
     }
-    
+
 })(this);


### PR DESCRIPTION
shouldn't it be like this?

``` js
to[name] = from[name];
```

and not 

``` js
from[name] = to[name];
```
